### PR TITLE
Closes #6 Add CLI option for saving drawing by revision number

### DIFF
--- a/drawing_splitter.py
+++ b/drawing_splitter.py
@@ -28,7 +28,7 @@ def get_pdf_length(filename):
         return num_of_pages
 
 
-def get_drawing_numbers(filename, num_of_pages, number_element, region):
+def get_dwg_info(filename, num_of_pages, number_element, region, rev=False):
     """Return a list of drawing numbers, read from each page of a PDF."""
     drawing_numbers = []
     for page_number in range(num_of_pages):
@@ -41,15 +41,23 @@ def get_drawing_numbers(filename, num_of_pages, number_element, region):
                                     + r'[\w\d\-\(\)]*')
             try:
                 drawing_number = re.search(search_str, text).group()
-                print(f'\tPage {page_number + 1} of '
-                      f'{num_of_pages}: {drawing_number}')
-                drawing_numbers.append(drawing_number)
+                print(f'\n\tPage {page_number + 1} of '
+                      f'{num_of_pages}: {drawing_number}', end=' ')
             except (TypeError, AttributeError):
-                print(f'\tPage {page_number + 1} of '
+                drawing_number = f'{os.path.basename(filename)[:-4]}' \
+                                 + f'_{page_number + 1}'
+                print(f'\n\tPage {page_number + 1} of '
                       f'{num_of_pages}: Drawing number not found. '
-                      'Manually rename file.')
-                drawing_numbers.append(f'{os.path.basename(filename)[:-4]}_'
-                                       f'{page_number + 1}')
+                      'Manually rename file.', end=' ')
+            drawing_numbers.append({drawing_number: None})
+            if rev:
+                search_str = re.compile(r'[CP]\d\d')
+                try:
+                    rev_number = re.search(search_str, text).group()
+                    drawing_numbers[page_number][drawing_number] = rev_number
+                    print(f'{rev_number}', end='')
+                except (TypeError, AttributeError):
+                    print(f'Revision not found.', end='')
     return drawing_numbers
 
 
@@ -63,13 +71,14 @@ def save_drawings(filename, num_of_pages, drawing_numbers, output_folder):
             pdf_writer = PyPDF2.PdfFileWriter()
             page = pdf_reader.getPage(page_number)
             pdf_writer.addPage(page)
-            output_filename = drawing_numbers[page_number] + '.pdf'
+            (drawing_number, rev), = drawing_numbers[page_number].items()
+            output_filename = drawing_number + '.pdf'
             os.makedirs(output_folder, exist_ok=True)
             output_fullpath = os.path.join(output_folder, output_filename)
             pdf_output_file = open(output_fullpath, 'wb')
             pdf_writer.write(pdf_output_file)
             pdf_output_file.close()
-        print(f'Drawings saved: {len(drawing_numbers)}')
+        print(f'\nDrawings saved: {len(drawing_numbers)}')
     warnings.filterwarnings('default')
 
 
@@ -124,16 +133,15 @@ if __name__ == '__main__':
                    'bot-right': (page_width * 0.8, page_height * 0.5,
                                  page_width, page_height),
                    'all': (0, 0, page_width, page_height)}
-        print(f'Processing file: {os.path.basename(filename)}...')
+        print(f'Processing file: {os.path.basename(filename)}...', end='')
         num_of_pages = get_pdf_length(filename)
         if args.custom is not None:
             region = 'custom'
             regions['custom'] = tuple(args.custom)
         else:
             region = args.preset
-        drawing_numbers = get_drawing_numbers(filename, num_of_pages,
-                                              number_element,
-                                              regions[region])
+        drawing_numbers = get_dwg_info(filename, num_of_pages, number_element,
+                                       regions[region], rev=args.revision)
         save_drawings(filename, num_of_pages, drawing_numbers, args.output)
         if args.delete:
             delete_file(filename)

--- a/user_options.py
+++ b/user_options.py
@@ -25,6 +25,10 @@ parser.add_argument('-d',
                     '--delete',
                     help="""Delete original files after processing""",
                     action='store_true')
+parser.add_argument('-r',
+                    '--revision',
+                    help="""Save drawings in folders by revision""",
+                    action='store_true')
 region_group = parser.add_mutually_exclusive_group()
 region_group.add_argument('-p',
                           '--preset',


### PR DESCRIPTION
Closes #6 
Add optional CLI flag to save drawings by revision number. New folder will be created for each revision found inside the specified output_folder if given.
Currently only supports the C01/P01 format.