### PR TITLE
Closes #4 - Add settings file for user defaults

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ Pillow==7.1.2
 pycryptodome==3.9.8
 PyPDF2==1.26.0
 sortedcontainers==2.2.2
+toml==0.10.1
 unicodecsv==0.14.1
 Wand==0.6.1

--- a/settings.toml
+++ b/settings.toml
@@ -1,0 +1,11 @@
+# settings.toml for drawing_splitter.py
+
+# Set defaults for usage
+# CLI arguments will override the defaults set here
+
+dwg_number_element = 'PROJECT'
+input_folder = '.'
+output_folder = '.'
+delete = false
+revision = false
+region = 'bot-right'

--- a/settings.toml
+++ b/settings.toml
@@ -3,9 +3,14 @@
 # Set defaults for usage
 # CLI arguments will override the defaults set here
 
-dwg_number_element = 'PROJECT'
-input_folder = '.'
-output_folder = '.'
-delete = false
-revision = false
-region = 'bot-right'
+dwg_number_element = 'PROJECT'  # Part of drawing number to be searched for
+input_folder = '.'              # Folder containing PDFs to be processed
+output_folder = '.'             # Folder to save drawings to
+
+# The following values must be true or false
+delete = false                  # Delete file after processing
+revision = false                # Save in folders based on revision number
+
+# Preset region
+# If a custom region is desired, please use the command line options
+region = 'bot-right'            # Choices: 'top-left', 'top-right', 'bot-left', bot-right'

--- a/user_options.py
+++ b/user_options.py
@@ -1,7 +1,26 @@
 import argparse
 import toml
 
-settings = toml.load('settings.toml')
+
+DEFAULTS = {'dwg_number_element': 'PROJECT',
+            'input_folder': '.',
+            'output_folder': '.',
+            'delete': False,
+            'revision': False,
+            'region': 'bot-right'}
+
+try:
+    settings = toml.load('settings.toml')
+except FileNotFoundError:
+    with open('settings.toml', 'w') as settings_file:
+        settings_file.write(toml.dumps(DEFAULTS))
+    settings = toml.load('settings.toml')
+    print('WARNING: Settings file does not exist.')
+    print('WARNING: Creating new settings file using DEFAULTS.')
+except toml.decoder.TomlDecodeError:
+    print('WARNING: Invalid settings file. Please ensure all options are set.')
+    print('WARNING: Using DEFAULTS.\n')
+    settings = DEFAULTS
 
 parser = argparse.ArgumentParser(description="""A tool for splitting multi-page
                                              PDF drawings into seperate files

--- a/user_options.py
+++ b/user_options.py
@@ -1,4 +1,7 @@
 import argparse
+import toml
+
+settings = toml.load('settings.toml')
 
 parser = argparse.ArgumentParser(description="""A tool for splitting multi-page
                                              PDF drawings into seperate files
@@ -6,29 +9,46 @@ parser = argparse.ArgumentParser(description="""A tool for splitting multi-page
 parser.add_argument('dwg_number_element',
                     metavar='dwg-number-element',
                     type=str,
-                    help='The part of the drawing number to be searched for')
+                    help='The part of the drawing number to be searched for',
+                    nargs='?',
+                    default=settings['dwg_number_element'])
 parser.add_argument('-i',
                     '--input',
                     metavar='FOLDER',
                     type=str,
                     help="""Folder where the original PDF files are located
                          (DEFAULT: Current folder)""",
-                    default='.')
+                    default=settings['input_folder'])
 parser.add_argument('-o',
                     '--output',
                     metavar='FOLDER',
                     type=str,
                     help="""Folder to save the PDF files in
                          (DEFAULT: Current folder)""",
-                    default='.')
-parser.add_argument('-d',
-                    '--delete',
-                    help="""Delete original files after processing""",
-                    action='store_true')
-parser.add_argument('-r',
-                    '--revision',
-                    help="""Save drawings in folders by revision""",
-                    action='store_true')
+                    default=settings['output_folder'])
+# If settings.toml is set to true, default needs to be true
+if settings['delete']:
+    parser.add_argument('-d',
+                        '--delete',
+                        help="""Delete original files after processing""",
+                        action='store_false')
+else:
+    parser.add_argument('-d',
+                        '--delete',
+                        help="""Delete original files after processing""",
+                        action='store_true')
+# If settings.toml is set to true, default needs to be true
+if settings['revision']:
+    parser.add_argument('-r',
+                        '--revision',
+                        help="""Save drawings in folders by revision""",
+                        action='store_false')
+else:
+    parser.add_argument('-r',
+                        '--revision',
+                        help="""Save drawings in folders by revision""",
+                        action='store_true')
+
 region_group = parser.add_mutually_exclusive_group()
 region_group.add_argument('-p',
                           '--preset',
@@ -38,7 +58,7 @@ region_group.add_argument('-p',
                                number. Choose from: 'top-left', 'top-right',
                                'bot-left', 'bot-right', 'all'
                                (DEFAULT: bot-right)""",
-                          default='bot-right',
+                          default=settings['region'],
                           choices=['top-left', 'top-right', 'bot-left',
                                    'bot-right', 'all'])
 region_group.add_argument('-c',


### PR DESCRIPTION
Closes #4 
settings.toml added to allow user to set defaults instead of having to specify options on the command line.

If command line options are specified, these override settings.toml

Invalid configs should be handled.